### PR TITLE
Add initial auth support for AST2400 based boards

### DIFF
--- a/core/input/keysym.js
+++ b/core/input/keysym.js
@@ -455,6 +455,11 @@ XK2HID[KeyTable.XK_underscore]   = XK2HID[KeyTable.XK_minus];
 XK2HID[KeyTable.XK_bar]          = XK2HID[KeyTable.XK_backslash];
 XK2HID[KeyTable.XK_quotedbl]     = XK2HID[KeyTable.XK_apostrophe];
 XK2HID[KeyTable.XK_asciitilde]   = XK2HID[KeyTable.XK_grave];
+XK2HID[KeyTable.XK_braceleft]    = XK2HID[KeyTable.XK_bracketleft];
+XK2HID[KeyTable.XK_braceright]   = XK2HID[KeyTable.XK_bracketright];
+XK2HID[KeyTable.XK_question]     = XK2HID[KeyTable.XK_slash];
+XK2HID[KeyTable.XK_colon]        = XK2HID[KeyTable.XK_semicolon];
+XK2HID[KeyTable.XK_plus]         = XK2HID[KeyTable.XK_equal];
 
 
 /* [module] export default KeyTable; */

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -47,6 +47,7 @@
 
     this._rfb_tightvnc = false;
     this._rfb_atenikvm = false;
+	this._rfb_insydevnc = false;
     this._rfb_xvp_ver = 0;
 
     // In preference order
@@ -322,9 +323,10 @@
             Util.Info("Sending Ctrl-Alt-Del");
 
             var keyEvent;
-            if (this._rfb_atenikvm) {
+			if (this._rfb_atenikvm || this._rfb_insydevnc) {
                 keyEvent = RFB.messages.atenKeyEvent;
-            } else {
+			}
+			else {
                 keyEvent = RFB.messages.keyEvent;
             }
 
@@ -362,9 +364,10 @@
             if (this._rfb_connection_state !== 'connected' || this._view_only) { return false; }
 
             var keyEvent;
-            if (this._rfb_atenikvm) {
+			if (this._rfb_atenikvm || this._rfb_insydevnc) {
                 keyEvent = RFB.messages.atenKeyEvent;
-            } else {
+			}
+			else {
                 keyEvent = RFB.messages.keyEvent;
             }
 
@@ -700,6 +703,7 @@
 
             var down = (keyevent.type == 'keydown');
             if (this._qemuExtKeyEventSupported) {
+				console.log('using qemu key event');
                 var scancode = XtScancode[keyevent.code];
                 if (scancode) {
                     var keysym = keyevent.keysym;
@@ -709,9 +713,10 @@
                 }
             } else {
                 keysym = keyevent.keysym.keysym;
-                if (this._rfb_atenikvm) {
+				if (this._rfb_atenikvm || this._rfb_insydevnc) {
                     RFB.messages.atenKeyEvent(this._sock, keysym, down);
-                } else {
+				}
+				 else {
                     RFB.messages.keyEvent(this._sock, keysym, down);
                 }
             }
@@ -737,7 +742,7 @@
                     // If the viewport didn't actually move, then treat as a mouse click event
                     // Send the button down event here, as the button up event is sent at the end of this function
                     if (!this._viewportHasMoved && !this._view_only) {
-                        if (this._rfb_atenikvm) {
+						if (this._rfb_atenikvm || this._rfb_insydevnc) {
                             RFB.messages.atenPointerEvent(this._sock, this._display.absX(x), this._display.absY(y), bmask);
                         } else {
                             RFB.messages.pointerEvent(this._sock, this._display.absX(x), this._display.absY(y), bmask);
@@ -750,9 +755,10 @@
             if (this._view_only) { return; } // View only, skip mouse events
 
             if (this._rfb_connection_state !== 'connected') { return; }
-            if (this._rfb_atenikvm) {
+			if (this._rfb_atenikvm || this._rfb_insydevnc) {
                 RFB.messages.atenPointerEvent(this._sock, this._display.absX(x), this._display.absY(y), this._mouse_buttonMask);
-            } else {
+			}
+			else {
                 RFB.messages.pointerEvent(this._sock, this._display.absX(x), this._display.absY(y), this._mouse_buttonMask);
             }
         },
@@ -781,7 +787,7 @@
             if (this._view_only) { return; } // View only, skip mouse events
 
             if (this._rfb_connection_state !== 'connected') { return; }
-            if (this._rfb_atenikvm) {
+			if (this._rfb_atenikvm|| this._rfb_insydevnc) {
                 RFB.messages.atenPointerEvent(this._sock, this._display.absX(x), this._display.absY(y), this._mouse_buttonMask);
             } else {
                 RFB.messages.pointerEvent(this._sock, this._display.absX(x), this._display.absY(y), this._mouse_buttonMask);
@@ -954,6 +960,7 @@
             if (this._sock.rQwait("auth challenge", definedAuthLen-4))
                 return false;
             this._rfb_insydevnc = true;
+			Util.Info('Using Insyde protocol extensions');
             var challenge = this._sock.rQshiftBytes(definedAuthLen);
             var sendUsername = [];
             var sendPassword = [];
@@ -975,6 +982,7 @@
             this._sock.send(sendPassword);
             this._sock.flush();
             this._rfb_init_state = "SecurityResult";
+
             return true
         },
 
@@ -1263,6 +1271,21 @@
                 // TIGHT encoding capabilities
                 this._sock.rQskipBytes(16 * numEncodings);
             }
+			else if (this._rfb_insydevnc) {
+				if (this._sock.rQwait("InsydeVNC extended server init header", 12, 24 + name_length))
+					return false;
+				this._sock.rQskipBytes(4);
+				var SessionID = this._sock.rQshift32();
+				var VideoEnable = this._sock.rQshift8();
+				var KbMsEnable = this._sock.rQshift8();
+				var KickUserEnable = this._sock.rQshift8();
+				var VMEnable = this._sock.rQshift8();
+				Util.Debug("SessionID: " + SessionID +
+							", VideoEnable: " + VideoEnable +
+							", KbMsEnable: " + KbMsEnable +
+							", KickUserEnable: " + KickUserEnable +
+							", VMEnable: " + VMEnable);
+			}
 
             // NB(directxman12): these are down here so that we don't run them multiple times
             //                   if we backtrack
@@ -1549,6 +1572,7 @@
             } else {
                 msg_type = this._sock.rQshift8();
             }
+			Util.Debug('Got msg type '+msg_type);
 
             if (this._rfb_atenikvm) {
                 // ATEN iKVM servers use a variety of proprietary messages that
@@ -1589,6 +1613,54 @@
                         return true;
                 }
             }
+			else if (this._rfb_insydevnc)
+			{
+				// Insyde appears to be very similar to ATEN...
+				// https://www.insyde.com/products/supervyse
+
+				switch (msg_type)
+				{
+					case 57:
+						count = this._sock.rQshiftBytes(4);
+						var tmp = this._sock.rQshiftBytes(4);
+						var ctrl_code = 0;
+						for (var i = 0; i < 4; i++)
+							ctrl_code += tmp[i] * Math.pow(10, 3 - i);
+						var cmsg = this._sock.rQshiftBytes(256);
+						Util.Debug(cmsg);
+						switch (ctrl_code)
+						{
+							case 0:
+							case 1:
+								Util.Debug('A user has connected (possibly you!)');
+							break;
+							case 2:
+								Util.Debug('A user has disonnected (was it you?)');
+							break;
+							case 3:
+								Util.Debug('Disconnected due to logout?');
+							break;
+							case 4:
+								Util.Debug('Too many active iKVM sessions');
+							break;
+							case 5:
+							case 6:
+							case 7:
+								// we may never know what these mean!
+							break;
+							case 8:
+								Util.Debug('Disconnected due to bios udpdate');
+							break;
+							case 9:
+								Util.Debug('Disconnected due to IPMI controller update');
+							break;
+						}
+						return true;
+
+					case 4:
+						Util.Debug('Insyde cursor pos request');
+				}
+			}
 
             switch (msg_type) {
                 case 0:  // FramebufferUpdate
@@ -1989,6 +2061,7 @@
             buff[offset + 17] = 0;
 
             sock._sQlen += 18;
+			sock.flush();
         },
 
         atenPointerEvent: function (sock, x, y, mask) {
@@ -2021,6 +2094,7 @@
             buff[offset + 17] = 0;
 
             sock._sQlen += 18;
+			sock.flush();
         },
 
         atenChangeVideoSettings: function (sock, lumaQt, chromaQt, subsamplingMode) {


### PR DESCRIPTION
Supermicro X11SSE-F boards use an entirely different auth scheme from the previous ones (but yes, they've hijacked auth type 16 again...). 

Luckily, they present a server version of 055.008, so they're pretty easy to detect.

Another change with these controllers, is you have to use websockify's --tls-client flag.  The IPMI controller now speaks VNC over SSL.

While this will successfully auth, it will not remain connected and actually work.  We end up disconnecting with 'Unexpected server message (Type: 66)', but it's a start.